### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -37,6 +39,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
 
     steps:
       - name: Download build artifacts


### PR DESCRIPTION
Potential fix for [https://github.com/smeetsee/adfs-keycloak-mfa/security/code-scanning/2](https://github.com/smeetsee/adfs-keycloak-mfa/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow to explicitly define the minimal permissions required for each job. The `build` job only needs `contents: read` to check out the repository and build the project. The `release` job requires `contents: read` to download artifacts and `contents: write` to create a GitHub release. These permissions will be added at the job level to ensure that each job has only the permissions it needs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
